### PR TITLE
Add economy news summarizer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,30 @@
-# hello-world
-#this is the test file to understand branch feature in GitHub
+# Economy News Summarizer
 
-#is this changes is valid? Plaese check
+This repository contains a simple Python script that fetches economy related
+articles from BBC and Reuters RSS feeds and summarizes each article using the
+OpenAI API.
+
+## Requirements
+
+- Python 3.8+
+- `requests`
+- `beautifulsoup4`
+- `feedparser`
+- `openai`
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Set your OpenAI API key in the environment variable `OPENAI_API_KEY` and run:
+
+```bash
+python economy_news_summary.py
+```
+
+The script will print the title, link and summary for each economy article found
+in the feeds.

--- a/economy_news_summary.py
+++ b/economy_news_summary.py
@@ -1,0 +1,67 @@
+import os
+import requests
+from bs4 import BeautifulSoup
+import feedparser
+import openai
+
+
+BBC_RSS = 'http://feeds.bbci.co.uk/news/business/economy/rss.xml'
+REUTERS_RSS = 'http://feeds.reuters.com/news/economy'
+
+
+class Article:
+    def __init__(self, title, link):
+        self.title = title
+        self.link = link
+        self.text = None
+        self.summary = None
+
+
+def fetch_rss_entries(url):
+    feed = feedparser.parse(url)
+    articles = []
+    for entry in feed.entries:
+        articles.append(Article(entry.title, entry.link))
+    return articles
+
+
+def fetch_article_text(article):
+    headers = {'User-Agent': 'Mozilla/5.0'}
+    r = requests.get(article.link, headers=headers, timeout=10)
+    soup = BeautifulSoup(r.text, 'html.parser')
+    paragraphs = [p.get_text() for p in soup.find_all('p')]
+    article.text = '\n'.join(paragraphs)
+
+
+def summarize(article, model='gpt-3.5-turbo'):
+    if not article.text:
+        return
+    prompt = (
+        "Summarize the following article about economy in a short paragraph:\n"
+        f"{article.text[:4000]}"
+    )
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    article.summary = response["choices"][0]["message"]["content"].strip()
+
+
+def main():
+    openai.api_key = os.environ.get('OPENAI_API_KEY')
+    if not openai.api_key:
+        raise EnvironmentError('OPENAI_API_KEY environment variable not set')
+
+    sources = [BBC_RSS, REUTERS_RSS]
+    articles = []
+    for src in sources:
+        articles.extend(fetch_rss_entries(src))
+
+    for art in articles:
+        fetch_article_text(art)
+        summarize(art)
+        print(f"Title: {art.title}\nLink: {art.link}\nSummary: {art.summary}\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+feedparser
+openai


### PR DESCRIPTION
## Summary
- add script to retrieve economy articles from BBC and Reuters RSS feeds
- generate summaries using OpenAI API
- document usage and dependencies

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile economy_news_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_6842dc06798883289e99fe4d4a08f2fd